### PR TITLE
Add support for redirect with cookie authentication

### DIFF
--- a/fetcher/lib/fetcher/worker.rb
+++ b/fetcher/lib/fetcher/worker.rb
@@ -154,6 +154,7 @@ module Fetcher
 
       redirect_limit = 6
       response = nil
+      cookie = nil
 
       until false
         raise ArgumentError, 'HTTP redirect too deep' if redirect_limit == 0
@@ -164,6 +165,7 @@ module Fetcher
         logger.debug "GET #{uri.request_uri} uri=#{uri}, redirect_limit=#{redirect_limit}"
 
         headers = { 'User-Agent' => "fetcher gem v#{VERSION}" }
+        headers['Cookie'] = cookie unless cookie.nil?
 
         if use_cache?
           ## check for existing cache entry in cache store (lookup by uri)
@@ -214,6 +216,7 @@ module Fetcher
             newuri = uri + response.header['location']
           end
           uri = newuri
+          cookie = response['Set-Cookie']
         else
           puts "*** error - fetch HTTP - #{response.code} #{response.message}"
           break  # will return response

--- a/fetcher/lib/fetcher/worker.rb
+++ b/fetcher/lib/fetcher/worker.rb
@@ -217,16 +217,13 @@ module Fetcher
           end
           uri = newuri
 
-          cookie_response = response['Set-Cookie']
-
-          if cookie_response.respond_to?('each')
+          cookie = response.get_fields('set-cookie')
+          if cookie.respond_to?('each')
             cookies_array = Array.new
             cookie.each { | cookie |
               cookies_array.push(cookie.split('; ')[0])
             }
             cookie_jar = cookies_array.join('; ')
-          else
-            cookie_jar = cookie_response
           end
 
           logger.debug "Set cookie: #{cookie_jar}"

--- a/fetcher/test/test_get.rb
+++ b/fetcher/test/test_get.rb
@@ -40,4 +40,16 @@ class TestGet < MiniTest::Test
     assert_equal '404', res.code
   end
 
+  def test_get_cookie_redirect
+    url = 'https://link.springer.com/search.rss?search-within=Journal&facet-journal-id=10827'
+    worker = Fetcher::Worker.new
+    res = worker.get( url )
+    pp res
+
+    assert_equal '200',        res.code             # note: returned code is a string e.g. '200' not 200
+    assert_equal 'OK',         res.message
+    assert_equal 'text/xml', res.content_type
+
+  end
+
 end # class TestGet


### PR DESCRIPTION
In relation to feedreader/pluto#39, the request cookie gets saved for each redirect. This should support cookie based authentication.

The test passes on my computer, but I am not good at ruby code so I don't know if this really fixes the issue.